### PR TITLE
some tools are for Gamecube only, update READMEs

### DIFF
--- a/filesystem/bfbs/README
+++ b/filesystem/bfbs/README
@@ -1,1 +1,1 @@
-bfbs 0.0 extracts the filesystem from sally.bf in Beyond Good & Evil (sally_clean.bf in the PC version)
+bfbs 0.0 extracts the filesystem from sally.bf in Beyond Good & Evil (Gamecube, sally_clean.bf in the PC version)

--- a/filesystem/pakthis/README
+++ b/filesystem/pakthis/README
@@ -1,1 +1,1 @@
-PAKthis 0.0 extracts files from the .bin files in Megaman X Collection. The audio seems to be mostly OGG Vorbis.
+PAKthis 0.0 extracts files from the .bin files in Megaman X Collection (Gamecube). The audio seems to be mostly OGG Vorbis.

--- a/multi/bbegex/README
+++ b/multi/bbegex/README
@@ -1,2 +1,2 @@
-bbegex extracts the files from "Filelist.000" and "Filelist.txt" in Batman Begins.
-sfxtract 0.0 will extract DSPs from SFX files that contain them, but it looks like most of the music in Batman Begins is stored in another format.
+bbegex extracts the files from "Filelist.000" and "Filelist.txt" in Batman Begins (Gamecube).
+sfxtract 0.0 will extract DSPs from SFX files that contain them, but it looks like most of the music in Batman Begins (Gamecube) is stored in another format.

--- a/soundbank/jbc/README
+++ b/soundbank/jbc/README
@@ -1,1 +1,1 @@
-Just an extractor for jbc files, such as found in NHL Hitz Pro
+Just an extractor for jbc files, such as found in NHL Hitz Pro (Gamecube)

--- a/soundbank/mood/README
+++ b/soundbank/mood/README
@@ -1,1 +1,1 @@
-Extract DSPs from the MOO files in Robotech: Battlecry with MOOd 0.0 (MOO depacker).
+Extract DSPs from the MOO files in Robotech: Battlecry (Gamecube) with MOOd 0.0 (MOO depacker).

--- a/soundbank/tmnt3mn/README
+++ b/soundbank/tmnt3mn/README
@@ -1,1 +1,1 @@
-Teenage Mutant Ninja Turtles 3: Mutant Nightmare has a file called strbgm.bin which contains all the DSPs. I wrote an extractor (0.1) which converts them to standard dual-file stereo DSPs.
+Teenage Mutant Ninja Turtles 3: Mutant Nightmare (Gamecube) has a file called strbgm.bin which contains all the DSPs. I wrote an extractor (0.1) which converts them to standard dual-file stereo DSPs.


### PR DESCRIPTION
In a number of READMEs I mention that a tool is for a game without saying
what platform for multi-platform games. Here's some clarification; it's usually
Gamecube.